### PR TITLE
fix websocket url by adding config var

### DIFF
--- a/views/components/home/input.vue
+++ b/views/components/home/input.vue
@@ -7,12 +7,13 @@
 
 <script>
 const io = require('socket.io-client');
+import { API_LOCATION } from "../../config";
 
 export default {
     data() {
         return {
             website: '',
-            socket: io('localhost:8080')
+            socket: io(API_LOCATION)
         }
     },
     methods: {

--- a/views/config/http.js
+++ b/views/config/http.js
@@ -1,8 +1,0 @@
-/* jshint node:true */
-'use strict';
-
-const axios = require('axios');
-
-export const http = axios.create({
-  baseUrl: 'http://localhost:8080/api'
-});

--- a/views/config/index.js
+++ b/views/config/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    API_LOCATION: 'http://192.168.1.13:8080'
+};


### PR DESCRIPTION
Websocket are actually created on `localhost:8080` but this tool can be used by different device so we need to create websocket with the main API based on a pre-defined IP and not with localhost.